### PR TITLE
baudrate now adjustable under linux

### DIFF
--- a/sers_linux.go
+++ b/sers_linux.go
@@ -27,7 +27,7 @@ func (bp *baseport) SetBaudRate(br int) error {
 	}
 
 	// using aliased baudrate
-	C.cfsetspeed(tio, C.B38400)
+	//C.cfsetspeed(tio, C.B38400)
 
 	err = bp.setattr(tio)
 	if err != nil {


### PR DESCRIPTION
Hi Michael,

I started investigating this afternoon the problem by myself. I think I found the solution. At least here I can use now arbitrary bitrates. I found here the solution: http://www.downtowndougbrown.com/2013/11/linux-custom-serial-baud-rates/

Please let me know if this also works in your setup.

Tobias